### PR TITLE
Support for Optional SensorMeta

### DIFF
--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -42,7 +42,12 @@ PLATFORMS = ["device_tracker", "sensor", "binary_sensor"]
 
 def getFromDict(dataDict, keyString):
     mapList = keyString.split(".")
-    return reduce(operator.getitem, mapList, dataDict)
+    safe_getitem = (
+        lambda latest_value, key: None
+        if latest_value is None
+        else operator.getitem(latest_value, key)
+    )
+    return reduce(safe_getitem, mapList, dataDict)
 
 
 @callback


### PR DESCRIPTION
Updated getFromDict() to return None when the key path does not resolve
recursively. Previously this would result in "TypeError: 'NoneType' object is
not subscriptable". This change is needed to support SenorMeta that does not
exist on all car types. Specifically this change is needed for a 911 that does
not support "remainingRanges.electricalRange.distance".