### PR TITLE
Handle Missing Root Keys

### DIFF
--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -44,7 +44,7 @@ def getFromDict(dataDict, keyString):
     mapList = keyString.split(".")
     safe_getitem = (
         lambda latest_value, key: None
-        if latest_value is None
+        if latest_value is None or key not in latest_value
         else operator.getitem(latest_value, key)
     )
     return reduce(safe_getitem, mapList, dataDict)


### PR DESCRIPTION
Updated getFromDict() to return None when root key being looked up is missing. Specifically, this change is needed for a 911 that does not support "chargingStatus".