### PR TITLE
minor fixes

### DIFF
--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -148,6 +148,8 @@ DEVICE_NAMES = {
     "remainingRanges.conventionalRange.distance": "range sensor",
     "remainingRanges.electricalRange.distance": "range sensor",
     "chargingStatus": "charger sensor",
+    "directClimatisation.climatisationState": "climatisation",
+    "directCharge.isActive": "direct charge"
 }
 
 ICONS = {

--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -149,7 +149,7 @@ DEVICE_NAMES = {
     "remainingRanges.electricalRange.distance": "range sensor",
     "chargingStatus": "charger sensor",
     "directClimatisation.climatisationState": "climatisation",
-    "directCharge.isActive": "direct charge"
+    "directCharge.isActive": "direct charge",
 }
 
 ICONS = {

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,4 +60,5 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        return data == "ON" or data == True
+        if data == "ON" or data == True:
+            return True

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -36,7 +36,7 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
             await self.coordinator.controller.climateOn(self.vin, True)
         elif self.meta.on_action == "directcharge-on":
             await self.coordinator.controller.directChargeOn(self.vin, None, True)
-        # await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off the switch."""
@@ -44,7 +44,7 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
             await self.coordinator.controller.climateOff(self.vin, True)
         elif self.meta.off_action == "directcharge-off":
             await self.coordinator.controller.directChargeOff(self.vin, None, True)
-        # await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
 
     @property
     def name(self):
@@ -60,5 +60,4 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        print(data)
-        return data == "ON"
+        return (data == "ON" or data == True)

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,5 +60,5 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        if data == "ON" or data == True:
+        if data == "ON" or data is True:
             return True

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,5 +60,4 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        if data == "ON" or data is True:
-            return True
+        return data == "ON" or data is True

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,4 +60,4 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        return (data == "ON" or data == True)
+        return data == "ON" or data == True

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -12,9 +12,7 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_mock_porscheconnect_config_entry
 
-TEST_CLIMATE_SWITCH_ENTITY_ID = (
-    "switch.taycan_turbo_s_climatisation"
-)
+TEST_CLIMATE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_climatisation"
 TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_direct_charge"
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,9 +13,9 @@ from homeassistant.core import HomeAssistant
 from . import setup_mock_porscheconnect_config_entry
 
 TEST_CLIMATE_SWITCH_ENTITY_ID = (
-    "switch.taycan_turbo_s_directclimatisation_climatisationstate"
+    "switch.taycan_turbo_s_climatisation"
 )
-TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_directcharge_isactive"
+TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_direct_charge"
 
 
 async def test_climate(


### PR DESCRIPTION
It appears as if directCharge.isActive returns bool while directClimatisation.climatisationState returns a string "ON" or "OFF". Added simple logic to accept both.

Also added naming for the switches, and uncommented async_request_refresh to avoid having the switch flip back to previous state before next regular update.



