### PR TITLE
Lock entity

### DIFF
--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -26,6 +26,7 @@ from .const import DATA_MAP
 from .const import DOMAIN
 from .const import STARTUP_MESSAGE
 from .const import SwitchMeta
+from .const import LockMeta
 
 
 # from homeassistant.const import ATTR_BATTERY_CHARGING
@@ -35,7 +36,7 @@ from .const import SwitchMeta
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=60)
 
-PLATFORMS = ["device_tracker", "sensor", "binary_sensor", "switch"]
+PLATFORMS = ["device_tracker", "sensor", "binary_sensor", "switch", "lock"]
 
 
 def getFromDict(dataDict, keyString):
@@ -155,6 +156,7 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     vehicle["components"] = {
                         "sensor": [],
                         "switch": [],
+                        "lock": [],
                         "binary_sensor": [],
                     }
                     for sensor_meta in DATA_MAP:
@@ -163,6 +165,8 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                             ha_type = "sensor"
                             if isinstance(sensor_meta, SwitchMeta):
                                 ha_type = "switch"
+                            if isinstance(sensor_meta, LockMeta):
+                                ha_type = "lock"
                             elif isinstance(sensor_meta, BinarySensorMeta):
                                 ha_type = "binary_sensor"
                             vehicle["components"][ha_type].append(sensor_meta)

--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -148,6 +148,8 @@ DEVICE_NAMES = {
     "remainingRanges.conventionalRange.distance": "range sensor",
     "remainingRanges.electricalRange.distance": "range sensor",
     "chargingStatus": "charger sensor",
+    "directClimatisation.climatisationState": "climatisation",
+    "directCharge.isActive": "direct charge"
 }
 
 ICONS = {

--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -149,7 +149,7 @@ DEVICE_NAMES = {
     "remainingRanges.electricalRange.distance": "range sensor",
     "chargingStatus": "charger sensor",
     "directClimatisation.climatisationState": "climatisation",
-    "directCharge.isActive": "direct charge"
+    "directCharge.isActive": "direct charge",
 }
 
 ICONS = {

--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -23,9 +23,16 @@ LOGGER = logging.getLogger(__package__)
 DEFAULT_SCAN_INTERVAL = 660
 HA_SENSOR = "sensor"
 HA_SWITCH = "switch"
+HA_LOCK = "lock"
 HA_DEVICE_TRACKER = "device_tracker"
 HA_BINARY_SENSOR = "binary_sensor"
-PORSCHE_COMPONENTS = [HA_SENSOR, HA_DEVICE_TRACKER, HA_BINARY_SENSOR, HA_SWITCH]
+PORSCHE_COMPONENTS = [
+    HA_SENSOR, 
+    HA_DEVICE_TRACKER, 
+    HA_BINARY_SENSOR, 
+    HA_SWITCH,
+    HA_LOCK,
+]
 
 NAME = "porscheconnect"
 DOMAIN_DATA = f"{DOMAIN}_data"
@@ -74,6 +81,15 @@ class SwitchMeta:
     default_enabled: bool = True
     attributes: list = field(default_factory=list)
 
+@dataclass
+class LockMeta:
+    name: str
+    key: str
+    icon: str = None
+    device_class: str = None
+    default_enabled: bool = True
+    attributes: list = field(default_factory=list)
+
 
 @dataclass
 class SensorAttr:
@@ -115,8 +131,7 @@ DATA_MAP = [
         "mdi:ev-station",
     ),
     BinarySensorMeta("parking brake", "parkingBreak", "mdi:lock"),
-    SensorMeta("doors", "doors.overallLockStatus", "mdi:lock"),
-    SensorMeta("lock", "overallOpenStatus", "mdi:lock"),
+    SensorMeta("doors", "overallOpenStatus", "mdi:lock"),
     SensorMeta(
         "charger sensor",
         "chargingStatus",
@@ -133,6 +148,11 @@ DATA_MAP = [
             SensorAttr("charging power", "batteryChargeStatus.chargingPower"),
         ],
     ),
+    LockMeta(
+        "doorlock",
+        "doors.overallLockStatus",
+        "mdi:lock"
+    )
 ]
 
 
@@ -150,6 +170,7 @@ DEVICE_NAMES = {
     "chargingStatus": "charger sensor",
     "directClimatisation.climatisationState": "climatisation",
     "directCharge.isActive": "direct charge",
+    "doors.overallLockStatus": "door lock"
 }
 
 ICONS = {

--- a/custom_components/porscheconnect/lock.py
+++ b/custom_components/porscheconnect/lock.py
@@ -38,7 +38,8 @@ class PorscheConnectLock(PorscheDevice, LockEntity):
 
     async def async_lock(self, **kwargs):  # pylint: disable=unused-argument
         """Lock the vechicle."""
-        _LOGGER.debug("Locking %s", self._name)
+        _LOGGER.debug("Locking %s", self._name)        
+        await self.coordinator.controller.lock(self.vin, True)
         await self.coordinator.async_request_refresh()
 
     async def async_unlock(self, **kwargs):  # pylint: disable=unused-argument

--- a/custom_components/porscheconnect/lock.py
+++ b/custom_components/porscheconnect/lock.py
@@ -1,0 +1,65 @@
+"""Lock platform for Porsche Connect."""
+import logging
+import json
+
+
+from homeassistant.components.lock import LockEntity
+
+from . import DOMAIN as PORSCHE_DOMAIN
+from . import PorscheDevice
+from .const import DEVICE_NAMES
+from .const import HA_LOCK
+from .const import LockMeta
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Setup lock platform."""
+    coordinator = hass.data[PORSCHE_DOMAIN][entry.entry_id]
+    entities = []
+    for vehicle in coordinator.vehicles:
+        for lock in vehicle["components"][HA_LOCK]:
+            entities.append(PorscheConnectLock(vehicle, coordinator, lock))
+    async_add_entities(entities)
+
+
+class PorscheConnectLock(PorscheDevice, LockEntity):
+    """Porsche Connect lock class."""
+
+    def __init__(self, vehicle, coordinator, lock_meta: LockMeta):
+        """Initialize the lock."""
+        super().__init__(vehicle, coordinator)
+        self.key = lock_meta.key
+        self.meta = lock_meta
+        device_name = DEVICE_NAMES.get(self.key, self.key)
+        self._name = f"{self._name} {device_name}"
+        self._unique_id = f"{super().unique_id}_{self.key}"
+
+    async def async_lock(self, **kwargs):  # pylint: disable=unused-argument
+        """Lock the vechicle."""
+        _LOGGER.debug("Locking %s", self._name)
+        await self.coordinator.async_request_refresh()
+
+    async def async_unlock(self, **kwargs):  # pylint: disable=unused-argument
+        """Unlock the vechicle."""
+        _LOGGER.debug("Unlocking %s", self._name)
+        PIN = kwargs['code'] or None
+        await self.coordinator.controller.unlock(self.vin, PIN, True)
+        await self.coordinator.async_request_refresh()
+        
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of this switch."""
+        return self.meta.icon
+
+    @property
+    def is_locked(self):
+        """Return true if the vehicle is locked."""
+        data = self.coordinator.getDataByVIN(self.vin, self.key)
+        return data == "CLOSED_LOCKED"

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,4 +60,5 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        return data == "ON" or data == True
+        if data == "ON" or data == True:
+            return True

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -36,7 +36,7 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
             await self.coordinator.controller.climateOn(self.vin, True)
         elif self.meta.on_action == "directcharge-on":
             await self.coordinator.controller.directChargeOn(self.vin, None, True)
-        # await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off the switch."""
@@ -44,7 +44,7 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
             await self.coordinator.controller.climateOff(self.vin, True)
         elif self.meta.off_action == "directcharge-off":
             await self.coordinator.controller.directChargeOff(self.vin, None, True)
-        # await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
 
     @property
     def name(self):
@@ -60,5 +60,4 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        print(data)
-        return data == "ON"
+        return (data == "ON" or data == True)

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,5 +60,5 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        if data == "ON" or data == True:
+        if data == "ON" or data is True:
             return True

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,5 +60,4 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        if data == "ON" or data is True:
-            return True
+        return data == "ON" or data is True

--- a/custom_components/porscheconnect/switch.py
+++ b/custom_components/porscheconnect/switch.py
@@ -60,4 +60,4 @@ class PorscheConnectSwitch(PorscheDevice, SwitchEntity):
     def is_on(self):
         """Return true if the switch is on."""
         data = self.coordinator.getDataByVIN(self.vin, self.key)
-        return (data == "ON" or data == True)
+        return data == "ON" or data == True

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -12,9 +12,7 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_mock_porscheconnect_config_entry
 
-TEST_CLIMATE_SWITCH_ENTITY_ID = (
-    "switch.taycan_turbo_s_climatisation"
-)
+TEST_CLIMATE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_climatisation"
 TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_direct_charge"
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,9 +13,9 @@ from homeassistant.core import HomeAssistant
 from . import setup_mock_porscheconnect_config_entry
 
 TEST_CLIMATE_SWITCH_ENTITY_ID = (
-    "switch.taycan_turbo_s_directclimatisation_climatisationstate"
+    "switch.taycan_turbo_s_climatisation"
 )
-TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_directcharge_isactive"
+TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_direct_charge"
 
 
 async def test_climate(


### PR DESCRIPTION
First stab at a lock entity, is seemingly working. PIN must be given as "code" parameter to the service lock.unlock. Could use some help with unit testing :-) 

Maybe I should have placed this against the dev branch, but discovered it too late! Should I move there?

