### PR TITLE
honk and flash services

### DIFF
--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -21,6 +21,8 @@ from pyporscheconnectapi.client import Client
 from pyporscheconnectapi.connection import Connection
 from pyporscheconnectapi.exceptions import PorscheException
 
+from .services import setup_services, unload_services
+
 from .const import BinarySensorMeta
 from .const import DATA_MAP
 from .const import DOMAIN
@@ -99,6 +101,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.async_add_job(
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
+
+    setup_services(hass)
 
     return True
 
@@ -216,6 +220,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            unload_services(hass)
 
     return unloaded
 

--- a/custom_components/porscheconnect/services.py
+++ b/custom_components/porscheconnect/services.py
@@ -1,0 +1,91 @@
+"""Support for Porsche Connect services."""
+# from __future__ import annotations
+
+import logging
+
+from .const import DOMAIN as PORSCHE_DOMAIN
+
+import voluptuous as vol
+
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+
+LOGGER = logging.getLogger(__name__)
+
+ATTR_VEHICLE = "vehicle"
+
+
+SERVICE_VEHICLE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_VEHICLE): cv.string,
+    }
+)
+
+SERVICE_HONK_AND_FLASH = "honk_and_flash"
+SERVICE_FLASH = "flash"
+
+SERVICES = [
+    SERVICE_HONK_AND_FLASH,
+    SERVICE_FLASH,
+]
+
+
+def setup_services(hass: HomeAssistant) -> None:
+    """Register the Porsche Connect services."""
+
+    async def honk_and_flash(service_call: ServiceCall) -> None:
+        """Request honk and flash from vehicle."""
+
+        LOGGER.debug("Honk and flash service request")
+
+        vehicledata = getvehicledata(service_call)
+        if "entry_id" in vehicledata:
+            coordinator = hass.data[PORSCHE_DOMAIN][vehicledata["entry_id"]]
+            await coordinator.controller.honkAndFlash(vehicledata["vin"], True)
+        else:
+            LOGGER.debug("Vehicle not found")
+
+    async def flash(service_call: ServiceCall) -> None:
+        """Request indicator flashes from vehicle."""
+
+        LOGGER.debug("Indicator flash request")
+
+        vehicledata = getvehicledata(service_call)
+        if "entry_id" in vehicledata:
+            coordinator = hass.data[PORSCHE_DOMAIN][vehicledata["entry_id"]]
+            res = await coordinator.controller.flash(vehicledata["vin"], True)
+            LOGGER.debug("Indicator flash result: %s", res)
+        else:
+            LOGGER.debug("Vehicle not found")
+
+    def getvehicledata(service_call: ServiceCall):
+        vehicledata = {}
+        dev_reg = dr.async_get(hass)
+        device = dev_reg.async_get(service_call.data[ATTR_VEHICLE])
+
+        for vdata in hass.data[PORSCHE_DOMAIN].values():
+            for vehicle in vdata.vehicles:
+                if (PORSCHE_DOMAIN, vehicle["vin"]) in device.identifiers:
+                    vehicledata["entry_id"] = list(device.config_entries)[0]
+                    vehicledata["vin"] = vehicle["vin"]
+
+        return vehicledata
+
+    hass.services.async_register(
+        PORSCHE_DOMAIN,
+        SERVICE_HONK_AND_FLASH,
+        honk_and_flash,
+        schema=SERVICE_VEHICLE_SCHEMA,
+    )
+    hass.services.async_register(
+        PORSCHE_DOMAIN,
+        SERVICE_FLASH,
+        flash,
+        schema=SERVICE_VEHICLE_SCHEMA,
+    )
+
+
+def unload_services(hass: HomeAssistant) -> None:
+    """Unload Porsche Connect services."""
+    for service in SERVICES:
+        hass.services.async_remove(PORSCHE_DOMAIN, service)

--- a/custom_components/porscheconnect/services.yaml
+++ b/custom_components/porscheconnect/services.yaml
@@ -1,0 +1,24 @@
+honk_and_flash:
+  name: Honk and flash
+  description: >
+    Briefly flashes the indicators and sounds the horn
+  fields:
+    vehicle:
+      name: Vehicle
+      description: The vehicle to send the command to.
+      required: true
+      selector:
+        device:
+          integration: porscheconnect
+flash:
+  name: Flash
+  description: >
+    Briefly flashes the indicators
+  fields:
+    vehicle:
+      name: Vehicle
+      description: The vehicle to send the command to.
+      required: true
+      selector:
+        device:
+          integration: porscheconnect


### PR DESCRIPTION
Finally took some time to look at adding services for honk and flash (and only flash). Since services are called from out of the blue and not in the context of a vehicle, and since we do not want to use the VIN to identify the vehicle, I've made an attempt to look up vehicle data from the device registry using device id and go from there.

One think that puzzles me is that the key to the coordinator (the entry_id) is really a set (containing a single element) in the registry. I'm not sure if that is a good way to get hold of the coordinator. Perhaps you have a better idea.
