### PR TITLE
Fix unit of measurement for distance sensor

### DIFF
--- a/custom_components/porscheconnect/sensor.py
+++ b/custom_components/porscheconnect/sensor.py
@@ -74,7 +74,7 @@ class PorscheSensor(PorscheDevice, Entity):
         #    return TIME_DAYS
         # if units == "MILES":
         #    return LENGTH_MILES
-        if units == "KILOMETER":
+        if units == "KILOMETERS":
             return LENGTH_KILOMETERS
 
     @property


### PR DESCRIPTION
Sneaky bug prevented setting a unit of measurement for distance sensors