### PR TITLE
Typo, fixes #115

### DIFF
--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -140,7 +140,7 @@ DATA_MAP = [
         "directcharge-off",
         "mdi:ev-station",
     ),
-    BinarySensorMeta("parking brake", "parkingBreak", "mdi:lock"),
+    BinarySensorMeta("parking brake", "parkingBrake", "mdi:lock"),
     SensorMeta("doors", "overallOpenStatus", "mdi:lock"),
     SensorMeta(
         "charger sensor",


### PR DESCRIPTION
There is a typo in the definition of the parking brake sensor, fixes #115