### PR TITLE
Add charging timer sensor

### DIFF
--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -172,6 +172,16 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     for item in vdata["chargingProfiles"]["profiles"]
                 }
             )
+            
+
+        vdata["timersDict"] = {}
+        vdata["currentTimerId"] = None
+        for item in vdata.get("timers", []):
+            if item.get("active", False) and vdata["currentTimerId"] is None:
+                vdata["currentTimerId"] = item["timerID"]
+            vdata["timersDict"].update({item["timerID"]: item})
+
+
         if vdata["services"]["vehicleServiceEnabledMap"]["CF"] == "ENABLED":
             vdata.update(await self.controller.getPosition(vin))
         return vdata
@@ -225,7 +235,7 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                             sensor_meta,
                             sensor_data,
                         )
-                        if sensor_data is not None:
+                        if sensor_data is not None or len(sensor_meta.attributes) > 0:
                             ha_type = "sensor"
                             if isinstance(sensor_meta, SwitchMeta):
                                 ha_type = "switch"

--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -172,7 +172,6 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     for item in vdata["chargingProfiles"]["profiles"]
                 }
             )
-            
 
         vdata["timersDict"] = {}
         vdata["currentTimerId"] = None
@@ -180,7 +179,6 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
             if item.get("active", False) and vdata["currentTimerId"] is None:
                 vdata["currentTimerId"] = item["timerID"]
             vdata["timersDict"].update({item["timerID"]: item})
-
 
         if vdata["services"]["vehicleServiceEnabledMap"]["CF"] == "ENABLED":
             vdata.update(await self.controller.getPosition(vin))

--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -125,6 +125,12 @@ DATA_MAP = [
         "mdi:battery-charging",
         attributes=[SensorAttr("profiles", "chargingProfilesDict")],
     ),
+    SensorMeta(
+        "charging timer",
+        "currentTimerId",
+        "mdi:car-clock",
+        attributes=[SensorAttr("timers", "timersDict")],
+    ),
     SwitchMeta(
         "climate",
         "directClimatisation.climatisationState",
@@ -176,6 +182,7 @@ DEVICE_NAMES = {
     "remainingRanges.electricalRange.distance": "range",
     "chargingStatus": "charger",
     "chargingProfiles.currentProfileId": "charging profile",
+    "currentTimerId": "charging timer",
     "directClimatisation.climatisationState": "climatisation",
     "directCharge.isActive": "direct charge",
     "doors.overallLockStatus": "door lock",


### PR DESCRIPTION
Similarly to the "Charing Profile" sensor, this adds an "Charging Timer" sensor.

If there is no timer active, the value will be None.
Otherwise it will be the ID of the current active timer. If there are multiple active timers, it will just be the ID of the first active timer.

It has a `timers` attribute with details about the different timers.

<img width="568" alt="ha" src="https://user-images.githubusercontent.com/1945577/236184323-29239d3f-0ed3-4820-9fa8-ee5a48848e9d.png">
