### PR TITLE
Avoid double naming of device tracker

### DIFF
--- a/custom_components/porscheconnect/device_tracker.py
+++ b/custom_components/porscheconnect/device_tracker.py
@@ -53,7 +53,6 @@ class PorscheDeviceTracker(PorscheBaseEntity, TrackerEntity):
         super().__init__(coordinator, vehicle)
 
         self._attr_unique_id = vehicle.vin
-        self._attr_name = vehicle.model_name
         self._tracking_enabled = True
         self._attr_icon = "mdi:crosshairs-gps"
 

--- a/custom_components/porscheconnect/device_tracker.py
+++ b/custom_components/porscheconnect/device_tracker.py
@@ -10,13 +10,13 @@ from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from pyporscheconnectapi.vehicle import PorscheVehicle
 
 from . import (
-    PorscheConnectDataUpdateCoordinator,
     PorscheBaseEntity,
+    PorscheConnectDataUpdateCoordinator,
 )
 from .const import DOMAIN
-from pyporscheconnectapi.vehicle import PorscheVehicle
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,17 +42,24 @@ async def async_setup_entry(
 
 
 class PorscheDeviceTracker(PorscheBaseEntity, TrackerEntity):
-    """Porsche Connect device tracker."""
+    """Class describing Porsche Connect device tracker."""
 
     def __init__(
         self,
         coordinator: PorscheConnectDataUpdateCoordinator,
         vehicle: PorscheVehicle,
     ) -> None:
-        """Initialize the device tracker"""
+        """Initialize the device tracker."""
         super().__init__(coordinator, vehicle)
 
         self._attr_unique_id = vehicle.vin
+        if (
+            vehicle.data["customName"] != vehicle.model_name
+            and vehicle.data["customName"] is not None
+        ):
+            self._attr_name = vehicle.data["customName"]
+        else:
+            self._attr_name = ""
         self._tracking_enabled = True
         self._attr_icon = "mdi:crosshairs-gps"
 
@@ -77,16 +84,14 @@ class PorscheDeviceTracker(PorscheBaseEntity, TrackerEntity):
         """Return latitude value of the device."""
         if self._tracking_enabled and self.vehicle.location[0] is not None:
             return float(self.vehicle.location[0])
-        else:
-            return None
+        return None
 
     @property
     def longitude(self) -> float | None:
         """Return longitude value of the device."""
         if self._tracking_enabled and self.vehicle.location[1] is not None:
             return float(self.vehicle.location[1])
-        else:
-            return None
+        return None
 
     @property
     def source_type(self) -> SourceType:


### PR DESCRIPTION
It appears HA names the device tracker using device-name + attr_name. Setting attr_name to the vehicle.model_name, where no nick name has been assigned, means naming it twice with the same string:

  Porsche Model Porsche Model