### PR TITLE
Use VIN instead of name for uniq keys

### DIFF
--- a/custom_components/porscheconnect/binary_sensor.py
+++ b/custom_components/porscheconnect/binary_sensor.py
@@ -125,7 +125,7 @@ class PorscheBinarySensor(BinarySensorEntity, PorscheBaseEntity):
 
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f'{vehicle.data["name"]}-{description.key}'
+        self._attr_unique_id = f'{vehicle.vin}-{description.key}'
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/porscheconnect/image.py
+++ b/custom_components/porscheconnect/image.py
@@ -99,7 +99,7 @@ class PorscheImage(PorscheBaseEntity, ImageEntity):
         self.entity_description = description
 
         self._attr_content_type = CONTENT_TYPE
-        self._attr_unique_id = f'{vehicle.data["name"]}-{description.key}'
+        self._attr_unique_id = f'{vehicle.vin}-{description.key}'
         self._attr_image_url = vehicle.picture_locations[description.view]
 
     async def async_added_to_hass(self):

--- a/custom_components/porscheconnect/lock.py
+++ b/custom_components/porscheconnect/lock.py
@@ -48,7 +48,7 @@ class PorscheLock(PorscheBaseEntity, LockEntity):
         """Initialize the lock."""
         super().__init__(coordinator, vehicle)
 
-        self._attr_unique_id = f'{vehicle.data["name"]}-lock'
+        self._attr_unique_id = f'{vehicle.vin}-lock'
         self.door_lock_state_available = vehicle.has_remote_services
 
     async def async_lock(self) -> None:

--- a/custom_components/porscheconnect/number.py
+++ b/custom_components/porscheconnect/number.py
@@ -94,7 +94,7 @@ class PorscheNumber(PorscheBaseEntity, NumberEntity):
         super().__init__(coordinator, vehicle)
 
         self.entity_description = description
-        self._attr_unique_id = f"{vehicle.data['name']}-{description.key}"
+        self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/porscheconnect/sensor.py
+++ b/custom_components/porscheconnect/sensor.py
@@ -188,7 +188,7 @@ class PorscheSensor(PorscheBaseEntity, SensorEntity):
         super().__init__(coordinator, vehicle)
 
         self.entity_description = description
-        self._attr_unique_id = f"{vehicle.data['name']}-{description.key}"
+        self._attr_unique_id = f"{vehicle.vin}-{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
With multiple cars, HomeAssistant complains that all cars are using the same uniq_id for entities. This results in most of them being disabled. After looking at the code, it's obvious that only ones working were buttons and switches. For those ha-porscheconnect uses VIN as part of the uniq_id, while for others it's using name.

This patch changes uniq_ids for image, binary_sensor, lock, number and sensor entities to VIN.

This patch does not handle the upgrade procedure, so just applying it will result in double entries in existing deployments. I'm not sure what's the best way to rename existing entries?