### PR TITLE
Update reconfigure/reauth flows for 2025.11+ requirements

### DIFF
--- a/custom_components/porscheconnect/config_flow.py
+++ b/custom_components/porscheconnect/config_flow.py
@@ -9,6 +9,8 @@ import voluptuous as vol
 from homeassistant import exceptions
 from homeassistant.config_entries import (
     CONN_CLASS_CLOUD_POLL,
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
     ConfigFlow,
     ConfigFlowResult,
 )
@@ -107,6 +109,21 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 **user_input,
                 CONF_ACCESS_TOKEN: info.get(CONF_ACCESS_TOKEN),
             }
+
+            if self.source == SOURCE_REAUTH:
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    self._get_reauth_entry(),
+                    data_updates=entry_data,
+                )
+
+            if self.source == SOURCE_RECONFIGURE:
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    self._get_reconfigure_entry(),
+                    data_updates=entry_data,
+                )
+
             return self.async_create_entry(
                 title=info["title"],
                 data=entry_data,
@@ -164,6 +181,21 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     **user_input,
                     CONF_ACCESS_TOKEN: info.get(CONF_ACCESS_TOKEN),
                 }
+
+                if self.source == SOURCE_REAUTH:
+                    self._abort_if_unique_id_mismatch()
+                    return self.async_update_reload_and_abort(
+                        self._get_reauth_entry(),
+                        data_updates=entry_data,
+                    )
+
+                if self.source == SOURCE_RECONFIGURE:
+                    self._abort_if_unique_id_mismatch()
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=entry_data,
+                    )
+
                 return self.async_create_entry(
                     title=info["title"],
                     data=entry_data,


### PR DESCRIPTION
I started getting an "Unknown Error" from the integration similar to those in #362. Upon investigation, it appears the use of `async_create_entry` in reconfiguration and reauthorization flows has been unsupported since 2025.11. See:

* [Dev Blog](https://developers.home-assistant.io/blog/2025/03/01/config-flow-unique-id/)
* home-assistant/core#154379

Also confirmed the current developer docs specifically say not to create a new entry: https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#reconfigure

This patch restores the ability to reauth/reconfigure for me.