### PR TITLE
Remove icon from state_of_charge sensor

### DIFF
--- a/custom_components/porscheconnect/sensor.py
+++ b/custom_components/porscheconnect/sensor.py
@@ -109,7 +109,6 @@ SENSOR_TYPES: list[PorscheSensorEntityDescription] = [
         translation_key="state_of_charge",
         measurement_node="BATTERY_LEVEL",
         measurement_leaf="percent",
-        icon="mdi:battery-medium",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,


### PR DESCRIPTION
Removed icon from `state_of_charge` sensor configuration so the default icon level and color from HA will change based on the state.

This works because the `device_class` is set to `battery` and `state_class` set to `measurement`