### PR TITLE
Add missing charging_stopped translation

### DIFF
--- a/custom_components/porscheconnect/translations/en.json
+++ b/custom_components/porscheconnect/translations/en.json
@@ -88,6 +88,7 @@
                     "charging": "Charging",
                     "charging_completed": "Charging completed",
                     "charging_error": "Charging error",
+                    "charging_stopped": "Charging stopped",
                     "initialising": "Initialising charging",
                     "instant_charging": "Instant charging",
                     "not_charging": "Not charging",

--- a/custom_components/porscheconnect/translations/sv.json
+++ b/custom_components/porscheconnect/translations/sv.json
@@ -118,6 +118,7 @@
                     "charging": "Laddar",
                     "charging_completed": "Laddning klar",
                     "charging_error": "Laddfel",
+                    "charging_stopped": "Laddning stoppad",
                     "initialising": "Initierar laddning",
                     "instant_charging": "Direktladdar",
                     "not_charging": "Laddar ej",


### PR DESCRIPTION
## Description
Adds the missing `charging_stopped` state to the `charging_status` sensor translations.

## Context
The Porsche API returns `CHARGING_STOPPED` when the charger stops charging (e.g., due to a scheduled end or external stop). The integration converts this to lowercase (`charging_stopped`), but this state was missing from the translation files, causing the raw string to be displayed in Home Assistant instead of a human-readable label.

## Changes
- `en.json`: Added `"charging_stopped": "Charging stopped"`
- `sv.json`: Added `"charging_stopped": "Laddning stoppad"`

## Related
Fixes missing state for sensor`charging_stopped`.