### PR TITLE
Retry setup when vehicle base data is incomplete

### DIFF
--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -132,6 +132,21 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     await vehicle.get_stored_overview()
                     await vehicle.get_picture_locations()
 
+                # get_stored_overview() catches PorscheExceptionError internally and returns
+                # normally, so a rate limited or otherwise failing API leaves vehicle.data
+                # without the base data it would have merged in - notably "name", which entity
+                # setup indexes directly. Treat that as a failed refresh: during setup
+                # async_config_entry_first_refresh() turns it into ConfigEntryNotReady and Home
+                # Assistant retries with backoff, instead of raising KeyError in every platform
+                # and leaving the integration with no entities until a manual reload.
+                incomplete = [v.vin for v in self.vehicles if "name" not in v.data]
+                if incomplete:
+                    # Drop them so the next attempt refetches instead of taking the branch
+                    # below, which would never call get_picture_locations() again.
+                    self.vehicles = []
+                    msg = "Incomplete data for vehicle(s) %s, will retry"
+                    raise UpdateFailed(msg % ", ".join(incomplete))
+
             else:
                 async with async_timeout.timeout(30):
                     for vehicle in self.vehicles:


### PR DESCRIPTION
Fixes #393.

`get_stored_overview()` in `pyporscheconnectapi` catches `PorscheExceptionError` internally and returns normally, so a rate limited API leaves `vehicle.data` without the base data it would have merged in — including `name`. No exception reaches the coordinator, so the refresh counts as successful, and entity setup then raises `KeyError: 'name'` in every platform. Home Assistant does not retry platform setup after that, so the integration ends up with a `loaded` config entry and zero entities until someone reloads it by hand.

This detects the incomplete data in the coordinator and fails the refresh instead. During setup `async_config_entry_first_refresh()` converts `UpdateFailed` into `ConfigEntryNotReady`, so Home Assistant retries with backoff and the integration recovers on its own once the API responds again.

`self.vehicles` is reset so the retry refetches, rather than falling into the `else` branch below, which would never call `get_picture_locations()` again.

### Why not a fallback for `vehicle.data["name"]`

That was my first instinct, but `sensor.py` builds `unique_id` from the same value. A fallback would mint different unique IDs whenever the data is incomplete and leave duplicate entities behind once the API recovers. Not creating entities from incomplete data at all avoids the problem instead of trading it for a subtler one.

### Testing

Isolated tests of the guard (complete data, missing base data, two vehicles with one incomplete, both incomplete, empty vehicle list, empty-string name) all behave as intended.

End-to-end on a live installation, simulating the swallowed failure with `vehicle.data.pop("name", None)` after the overview call:

- **before:** `KeyError: 'name'` in `sensor`, `binary_sensor`, `device_tracker`, `lock` and `image`; config entry `loaded`, no entities, no recovery
- **after:** config entry `setup_retry`, reason `Incomplete data for vehicle(s) <vin>, will retry`, automatic retries

With the simulation removed and normal API responses, all entities come back unchanged — no change to unique IDs or entity IDs.

### Note

Arguably `get_stored_overview()` should let the exception propagate rather than swallow it; the coordinator already handles `PorscheExceptionError` correctly. That is the more complete fix but touches `pyporscheconnectapi`, so it is not part of this PR.
