### PR TITLE
Cleanup captcha auth data

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-layout pyenv 3.12.2
+layout pyenv 3.14.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements_test.txt
+
+      - name: Install test dependencies
+        run: python -m pip install -r requirements_test.txt
+
+      - name: Run tests
+        run: python -m pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.16.5
     hooks:
       - id: ruff
       - id: ruff-format

--- a/custom_components/porscheconnect/__init__.py
+++ b/custom_components/porscheconnect/__init__.py
@@ -1,12 +1,12 @@
 """The Porsche Connect integration."""
 
+import asyncio
 import copy
 import logging
 import operator
 from datetime import timedelta
 from functools import reduce
 
-import async_timeout
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant, callback
@@ -23,7 +23,7 @@ from pyporscheconnectapi.connection import Connection
 from pyporscheconnectapi.exceptions import PorscheExceptionError
 from pyporscheconnectapi.vehicle import PorscheVehicle
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS, TRANSIENT_AUTH_FIELDS
 
 _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=DEFAULT_SCAN_INTERVAL)
@@ -54,6 +54,21 @@ def _async_save_token(hass, config_entry, access_token):
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up this integration using YAML is not supported."""
+    return True
+
+
+async def async_migrate_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> bool:
+    """Remove obsolete authentication challenge data from config entries."""
+    if config_entry.version == 1:
+        data = {
+            key: value
+            for key, value in config_entry.data.items()
+            if key not in TRANSIENT_AUTH_FIELDS
+        }
+        hass.config_entries.async_update_entry(config_entry, data=data, version=2)
     return True
 
 
@@ -133,7 +148,7 @@ class PorscheConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     await vehicle.get_picture_locations()
 
             else:
-                async with async_timeout.timeout(30):
+                async with asyncio.timeout(30):
                     for vehicle in self.vehicles:
                         await vehicle.get_stored_overview()
 

--- a/custom_components/porscheconnect/binary_sensor.py
+++ b/custom_components/porscheconnect/binary_sensor.py
@@ -125,7 +125,7 @@ class PorscheBinarySensor(BinarySensorEntity, PorscheBaseEntity):
 
         self.coordinator = coordinator
         self.entity_description = description
-        self._attr_unique_id = f'{vehicle.data["name"]}-{description.key}'
+        self._attr_unique_id = f"{vehicle.data['name']}-{description.key}"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/porscheconnect/config_flow.py
+++ b/custom_components/porscheconnect/config_flow.py
@@ -23,7 +23,13 @@ from pyporscheconnectapi.exceptions import (
     PorscheWrongCredentialsError,
 )
 
-from .const import DOMAIN
+from .const import (
+    CONF_CAPTCHA_CODE,
+    CONF_CODE_VERIFIER,
+    CONF_OAUTH_STATE,
+    DOMAIN,
+    TRANSIENT_AUTH_FIELDS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,9 +47,9 @@ async def validate_input(data):
         conn = Connection(
             email=data[CONF_EMAIL],
             password=data[CONF_PASSWORD],
-            captcha_code=data.get("captcha_code"),
-            state=data.get("state"),
-            code_verifier=data.get("code_verifier"),
+            captcha_code=data.get(CONF_CAPTCHA_CODE),
+            state=data.get(CONF_OAUTH_STATE),
+            code_verifier=data.get(CONF_CODE_VERIFIER),
             token=token,
         )
     except PorscheExceptionError as exc:
@@ -58,8 +64,8 @@ async def validate_input(data):
             "email": data[CONF_EMAIL],
             "password": data[CONF_PASSWORD],
             "captcha": exc.captcha,
-            "state": exc.state,
-            "code_verifier": exc.code_verifier,
+            CONF_OAUTH_STATE: exc.state,
+            CONF_CODE_VERIFIER: exc.code_verifier,
         }
     except PorscheWrongCredentialsError as exc:
         _LOGGER.info("Wrong credentials.")
@@ -77,7 +83,7 @@ async def validate_input(data):
 class ConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Porsche Connect."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
     email = None
@@ -113,6 +119,22 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             return
         self._abort_if_unique_id_mismatch()
 
+    @callback
+    def _get_entry_data(self, email: str, password: str, access_token) -> dict:
+        """Build persistent config entry data without transient auth fields."""
+        entry = self._get_entry_for_current_flow()
+        entry_data = dict(entry.data) if entry else {}
+        for field in TRANSIENT_AUTH_FIELDS:
+            entry_data.pop(field, None)
+        entry_data.update(
+            {
+                CONF_EMAIL: email,
+                CONF_PASSWORD: password,
+                CONF_ACCESS_TOKEN: access_token,
+            },
+        )
+        return entry_data
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if user_input is None:
@@ -136,17 +158,18 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.state = info.get("state")
                 self.code_verifier = info.get("code_verifier")
                 return self._async_form_captcha()
-            entry_data = {
-                **user_input,
-                CONF_ACCESS_TOKEN: info.get(CONF_ACCESS_TOKEN),
-            }
+            entry_data = self._get_entry_data(
+                user_input[CONF_EMAIL],
+                user_input[CONF_PASSWORD],
+                info.get(CONF_ACCESS_TOKEN),
+            )
 
             if self.source == SOURCE_REAUTH:
                 self._abort_if_account_mismatch()
                 return self.async_update_reload_and_abort(
                     self._get_reauth_entry(),
                     unique_id=self.unique_id,
-                    data_updates=entry_data,
+                    data=entry_data,
                 )
 
             if self.source == SOURCE_RECONFIGURE:
@@ -154,7 +177,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_update_reload_and_abort(
                     self._get_reconfigure_entry(),
                     unique_id=self.unique_id,
-                    data_updates=entry_data,
+                    data=entry_data,
                 )
 
             return self.async_create_entry(
@@ -194,7 +217,12 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_change_password(self, user_input=None) -> ConfigFlowResult:
         """Show the change password step."""
         if user_input is not None:
-            return await self.async_step_user(self._existing_entry_data | user_input)
+            return await self.async_step_user(
+                {
+                    CONF_EMAIL: self._existing_entry_data[CONF_EMAIL],
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                },
+            )
 
         return self.async_show_form(
             step_id="change_password",
@@ -213,9 +241,9 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input = {
                 CONF_EMAIL: self.email,
                 CONF_PASSWORD: self.password,
-                "captcha_code": user_input["captcha_code"],
-                "state": self.state,
-                "code_verifier": self.code_verifier,
+                CONF_CAPTCHA_CODE: user_input[CONF_CAPTCHA_CODE],
+                CONF_OAUTH_STATE: self.state,
+                CONF_CODE_VERIFIER: self.code_verifier,
             }
             errors = {}
             try:
@@ -228,17 +256,18 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.code_verifier = info.get("code_verifier")
                     return self._async_form_captcha()
 
-                entry_data = {
-                    **user_input,
-                    CONF_ACCESS_TOKEN: info.get(CONF_ACCESS_TOKEN),
-                }
+                entry_data = self._get_entry_data(
+                    user_input[CONF_EMAIL],
+                    user_input[CONF_PASSWORD],
+                    info.get(CONF_ACCESS_TOKEN),
+                )
 
                 if self.source == SOURCE_REAUTH:
                     self._abort_if_account_mismatch()
                     return self.async_update_reload_and_abort(
                         self._get_reauth_entry(),
                         unique_id=self.unique_id,
-                        data_updates=entry_data,
+                        data=entry_data,
                     )
 
                 if self.source == SOURCE_RECONFIGURE:
@@ -246,7 +275,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     return self.async_update_reload_and_abort(
                         self._get_reconfigure_entry(),
                         unique_id=self.unique_id,
-                        data_updates=entry_data,
+                        data=entry_data,
                     )
 
                 return self.async_create_entry(
@@ -260,7 +289,10 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
                     step_id="captcha",
                     data_schema=vol.Schema(
                         {
-                            vol.Required("captcha_code", default=vol.UNDEFINED): str,
+                            vol.Required(
+                                CONF_CAPTCHA_CODE,
+                                default=vol.UNDEFINED,
+                            ): str,
                         },
                     ),
                     errors=errors,
@@ -291,7 +323,7 @@ class ConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="captcha",
             data_schema=vol.Schema(
                 {
-                    vol.Required("captcha_code", default=vol.UNDEFINED): str,
+                    vol.Required(CONF_CAPTCHA_CODE, default=vol.UNDEFINED): str,
                 },
             ),
             description_placeholders={

--- a/custom_components/porscheconnect/const.py
+++ b/custom_components/porscheconnect/const.py
@@ -3,6 +3,14 @@
 DOMAIN = "porscheconnect"
 DEFAULT_SCAN_INTERVAL = 1920
 
+CONF_CAPTCHA_CODE = "captcha_code"
+CONF_CODE_VERIFIER = "code_verifier"
+CONF_OAUTH_STATE = "state"
+
+TRANSIENT_AUTH_FIELDS = frozenset(
+    {CONF_CAPTCHA_CODE, CONF_CODE_VERIFIER, CONF_OAUTH_STATE},
+)
+
 NAME = "porscheconnect"
 DOMAIN_DATA = f"{DOMAIN}_data"
 VERSION = "0.1.10"

--- a/custom_components/porscheconnect/device_tracker.py
+++ b/custom_components/porscheconnect/device_tracker.py
@@ -54,8 +54,8 @@ class PorscheDeviceTracker(PorscheBaseEntity, TrackerEntity):
 
         self._attr_unique_id = vehicle.vin
         if (
-            "customName" in vehicle.data and
-            vehicle.data["customName"] != vehicle.model_name
+            "customName" in vehicle.data
+            and vehicle.data["customName"] != vehicle.model_name
             and vehicle.data["customName"] is not None
         ):
             self._attr_name = vehicle.data["customName"]

--- a/custom_components/porscheconnect/image.py
+++ b/custom_components/porscheconnect/image.py
@@ -100,7 +100,7 @@ class PorscheImage(PorscheBaseEntity, ImageEntity):
         self.entity_description = description
 
         self._attr_content_type = CONTENT_TYPE
-        self._attr_unique_id = f'{vehicle.data["name"]}-{description.key}'
+        self._attr_unique_id = f"{vehicle.data['name']}-{description.key}"
         self._attr_image_url = vehicle.picture_locations[description.view]
 
     async def async_added_to_hass(self):

--- a/custom_components/porscheconnect/lock.py
+++ b/custom_components/porscheconnect/lock.py
@@ -48,7 +48,7 @@ class PorscheLock(PorscheBaseEntity, LockEntity):
         """Initialize the lock."""
         super().__init__(coordinator, vehicle)
 
-        self._attr_unique_id = f'{vehicle.data["name"]}-lock'
+        self._attr_unique_id = f"{vehicle.data['name']}-lock"
         self.door_lock_state_available = vehicle.has_remote_services
 
     async def async_lock(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ exclude = [ "tests/*.py" ]
 
 [tool.ruff.lint]
 select = [ "ALL" ]
-ignore = [ "ANN001", "ANN201", "ANN202", "ANN204", "ARG001", "ARG002", "CPY001", "TC001", "TC002", "TC003", "COM812", "ISC001", "PLC0415" ]
+ignore = [ "ANN001", "ANN201", "ANN202", "ANN204", "ARG001", "ARG002", "CPY001", "D203", "D213", "TC001", "TC002", "TC003", "COM812", "ISC001", "PLC0415" ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
+-r requirements_test.txt
 pre-commit==4.5.1
 ruff>=0.8
-homeassistant
-pyporscheconnectapi
-pytest

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
--r requirements_dev.txt
-pytest-homeassistant-custom-component
+pytest-homeassistant-custom-component==0.13.357
+pyporscheconnectapi==0.2.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool:pytest]
 addopts = -qq --cov=custom_components.porscheconnect
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
 console_output_style = count
 
 [coverage:run]
@@ -7,4 +9,4 @@ branch = False
 
 [coverage:report]
 show_missing = true
-fail_under = 100
+fail_under = 80

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,10 +1,8 @@
 """Tests for Porsche Connect integration."""
 from __future__ import annotations
 
-import json
 from typing import Any
 from unittest.mock import Mock
-from unittest.mock import patch
 
 from custom_components.porscheconnect import DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -14,12 +12,6 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from .const import MOCK_CONFIG
 
 TEST_CONFIG_ENTRY_ID = "77889900ac"
-
-
-def load_fixture_json(name):
-    with open(f"tests/fixtures/{name}.json") as json_file:
-        data = json.load(json_file)
-        return data
 
 
 def create_mock_porscheconnect_config_entry(
@@ -51,30 +43,6 @@ async def setup_mock_porscheconnect_config_entry(
     """Add a mock porscheconnect config entry to hass."""
     config_entry = config_entry or create_mock_porscheconnect_config_entry(hass, data)
 
-    fixture_name = "taycan"
-    fixture_data = load_fixture_json(fixture_name)
-    print(f"Using mock connedion fixture {fixture_name}")
-
-    async def mock_get(self, url, params=None):
-        print(f"Mock connection GET {url}")
-        print(params)
-        ret = fixture_data["GET"].get(url, {})
-        print(ret)
-        return ret
-
-    async def mock_post(self, url, data=None, json=None):
-        print(f"POST {url}")
-        print(data)
-        print(json)
-        return {}
-
-    async def mock_tokens(self, application, wasExpired=False):
-        print(f"Request mock token {application}")
-        return {}
-
-    with patch("pyporscheconnectapi.client.Connection.get", mock_get), patch(
-        "pyporscheconnectapi.client.Connection.post", mock_post
-    ), patch("pyporscheconnectapi.client.Connection._requestToken", mock_tokens):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
     return config_entry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,288 +1,155 @@
 """Global fixtures for Porsche Connect integration."""
 
-import asyncio
-from typing import Any
-from unittest.mock import patch
+import copy
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from pyporscheconnectapi.exceptions import PorscheException
-from pyporscheconnectapi.exceptions import PorscheWrongCredentials
+from pyporscheconnectapi.exceptions import PorscheExceptionError
+from pyporscheconnectapi.vehicle import PorscheVehicle
 
-from . import load_fixture_json
+MOCK_VEHICLE_DATA = {
+    "vin": "WPTAYCAN",
+    "name": "Taycan Turbo S",
+    "modelName": "Taycan Turbo S",
+    "modelType": {"engine": "BEV", "year": "2021"},
+    "REMOTE_ACCESS_AUTHORIZATION": {"isEnabled": True},
+    "GLOBAL_PRIVACY_MODE": {"isEnabled": False},
+    "PARKING_BRAKE": {"isOn": True},
+    "PARKING_LIGHT": {"isOn": False},
+    "LOCK_STATE_VEHICLE": {"isLocked": True},
+    "OPEN_STATE_DOOR_FRONT_LEFT": {"isOpen": False},
+    "OPEN_STATE_DOOR_FRONT_RIGHT": {"isOpen": False},
+    "TIRE_PRESSURE": {
+        "frontLeftTire": {"differenceBar": 0.1},
+        "frontRightTire": {"differenceBar": 0.1},
+    },
+    "BATTERY_LEVEL": {"percent": 96},
+    "E_RANGE": {"kilometers": 348},
+    "MILEAGE": {"kilometers": 13247},
+    "CHARGING_SUMMARY": {
+        "minSoC": 25,
+        "mode": "PROFILE",
+        "status": "NOT_CHARGING",
+        "targetDateTimeWithOffset": None,
+    },
+    "CHARGING_RATE": {"chargingRate-kph": 0, "chargingPower": 0},
+    "CLIMATIZER_STATE": {"isOn": False},
+}
 
-# from unittest.mock import Mock
 
-pytest_plugins = "pytest_homeassistant_custom_component"
-
-
-def async_return(result):
-    f = asyncio.Future()
-    f.set_result(result)
-    return f
-
-
-# This fixture is used to prevent HomeAssistant from attempting to create and dismiss persistent
-# notifications. These calls would fail without this fixture since the persistent_notification
-# integration is never loaded during a test.
-@pytest.fixture(name="skip_notifications", autouse=True)
-def skip_notifications_fixture():
-    """Skip notification calls."""
-    with patch("homeassistant.components.persistent_notification.async_create"), patch(
-        "homeassistant.components.persistent_notification.async_dismiss"
-    ):
-        yield
+def create_vehicle() -> PorscheVehicle:
+    """Create a vehicle using the current pyporscheconnectapi model."""
+    vehicle = PorscheVehicle(
+        connection=AsyncMock(),
+        data=copy.deepcopy(MOCK_VEHICLE_DATA),
+    )
+    vehicle.get_stored_overview = AsyncMock()
+    vehicle.get_picture_locations = AsyncMock()
+    return vehicle
 
 
-@pytest.fixture(name="auto_enable_custom_integrations", autouse=True)
-def auto_enable_custom_integrations(
-    hass: Any, enable_custom_integrations: Any  # noqa: F811
-) -> None:
-    """Enable custom integrations defined in the test dir."""
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable custom integrations defined in the test directory."""
+    yield
 
 
 @pytest.fixture
 def mock_connection():
-    """Prevent setup."""
-
-    fixture_name = "taycan"
-    fixture_data = load_fixture_json(fixture_name)
-    print(f"Using mock connedion fixture {fixture_name}")
-
-    async def mock_get(self, url, params=None):
-        print(f"Mock connection GET {url}")
-        print(params)
-        ret = fixture_data["GET"].get(url, {})
-        print(ret)
-        return ret
-
-    async def mock_post(self, url, data=None, json=None):
-        print(f"Mock connection POST {url}")
-        print(data)
-        print(json)
-        ret = fixture_data["POST"].get(url, {})
-        print(ret)
-        return ret
-
-    async def mock_tokens(self, application, wasExpired=False):
-        print(f"Request mock token for {application}")
-        return {}
-
-    async def mock_getAllTokens(self):
-        return {}
-
-    with patch("pyporscheconnectapi.client.Connection.get", mock_get), patch(
-        "pyporscheconnectapi.client.Connection.post", mock_post
-    ), patch(
-        "pyporscheconnectapi.client.Connection.getAllTokens", mock_getAllTokens
-    ), patch(
-        "pyporscheconnectapi.client.Connection._requestToken", mock_tokens
+    """Return one vehicle without making Porsche API requests."""
+    vehicle = create_vehicle()
+    with patch(
+        "pyporscheconnectapi.account.PorscheConnectAccount.get_vehicles",
+        AsyncMock(return_value=[vehicle]),
     ):
-        yield
+        yield vehicle
 
 
 @pytest.fixture
-def mock_connection_privacy():
-    """Prevent setup."""
-
-    fixture_name = "taycan_privacy"
-    fixture_data = load_fixture_json(fixture_name)
-
-    print(f"Using mock connedion fixture {fixture_name}")
-
-    async def mock_get(self, url, params=None):
-        print(f"Mock connection GET {url}")
-        print(params)
-        ret = fixture_data["GET"].get(url, {})
-        print(ret)
-        return ret
-
-    async def mock_post(self, url, data=None, json=None):
-        print(f"Mock connection POST {url}")
-        print(data)
-        print(json)
-        ret = fixture_data["POST"].get(url, {})
-        print(ret)
-        return ret
-
-    async def mock_tokens(self, application, wasExpired=False):
-        print(f"Request mock token for {application}")
-        return {}
-
-    async def mock_getAllTokens(self):
-        return {}
-
-    with patch("pyporscheconnectapi.client.Connection.get", mock_get), patch(
-        "pyporscheconnectapi.client.Connection.post", mock_post
-    ), patch(
-        "pyporscheconnectapi.client.Connection.getAllTokens", mock_getAllTokens
-    ), patch(
-        "pyporscheconnectapi.client.Connection._requestToken", mock_tokens
+def mock_connection_error():
+    """Raise an API error while loading vehicles."""
+    with patch(
+        "pyporscheconnectapi.account.PorscheConnectAccount.get_vehicles",
+        AsyncMock(side_effect=PorscheExceptionError("Test")),
     ):
-        yield
-
-
-@pytest.fixture
-def mock_noaccess(mock_connection):
-    """Return a mocked client object."""
-
-    async def mock_access(self, vin):
-        return {"allowed": False, "reason": "Test reason"}
-
-    with patch("custom_components.porscheconnect.Client.isAllowed", mock_access):
         yield
 
 
 @pytest.fixture
 def mock_lock_lock(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.lock") as mock_lock:
+    """Mock locking a vehicle."""
+    with patch(
+        "pyporscheconnectapi.remote_services.RemoteServices.lock_vehicle",
+        AsyncMock(),
+    ) as mock_lock:
         yield mock_lock
 
 
 @pytest.fixture
 def mock_lock_unlock(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.unlock") as mock_unlock:
+    """Mock unlocking a vehicle."""
+    with patch(
+        "pyporscheconnectapi.remote_services.RemoteServices.unlock_vehicle",
+        AsyncMock(),
+    ) as mock_unlock:
         yield mock_unlock
 
 
 @pytest.fixture
 def mock_set_charging_level(mock_connection):
-    """Return a mocked client object."""
+    """Mock changing the target state of charge."""
     with patch(
-        "custom_components.porscheconnect.Client.updateChargingProfile"
+        "pyporscheconnectapi.remote_services.RemoteServices.set_target_soc",
+        AsyncMock(),
     ) as set_level:
         yield set_level
 
 
 @pytest.fixture
-def mock_honk_and_flash(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.honkAndFlash") as honkflash:
-        yield honkflash
-
-
-@pytest.fixture
-def mock_flash(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.flash") as flash:
-        yield flash
-
-
-@pytest.fixture
 def mock_set_climate_on(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.climateOn") as climate_on:
+    """Mock starting climatisation."""
+    with patch(
+        "pyporscheconnectapi.remote_services.RemoteServices.climatise_on",
+        AsyncMock(),
+    ) as climate_on:
         yield climate_on
 
 
 @pytest.fixture
 def mock_set_climate_off(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.climateOff") as climate_off:
+    """Mock stopping climatisation."""
+    with patch(
+        "pyporscheconnectapi.remote_services.RemoteServices.climatise_off",
+        AsyncMock(),
+    ) as climate_off:
         yield climate_off
 
 
 @pytest.fixture
 def mock_set_charge_on(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.directChargeOn") as charge_on:
+    """Mock enabling direct charging."""
+    with patch(
+        "pyporscheconnectapi.remote_services.RemoteServices.direct_charge_on",
+        AsyncMock(),
+    ) as charge_on:
         yield charge_on
 
 
 @pytest.fixture
 def mock_set_charge_off(mock_connection):
-    """Return a mocked client object."""
-    with patch("custom_components.porscheconnect.Client.directChargeOff") as charge_off:
+    """Mock disabling direct charging."""
+    with patch(
+        "pyporscheconnectapi.remote_services.RemoteServices.direct_charge_off",
+        AsyncMock(),
+    ) as charge_off:
         yield charge_off
 
 
-@pytest.fixture(name="mock_client")
-def mock_client_fixture():
-    """Prevent setup."""
-    with patch("custom_components.porscheconnect.Client") as mock:
-        instance = mock.return_value
-        instance.getVehicles.return_value = async_return([])
-        instance.getAllTokens.return_value = async_return([])
-        instance.isTokenRefreshed.return_value = False
-        yield
-
-
-@pytest.fixture(name="mock_client_error")
-def mock_client_error_fixture():
-    """Prevent setup."""
-    with patch("custom_components.porscheconnect.Client") as mock:
-        instance = mock.return_value
-        instance.getVehicles.return_value = async_return([])
-        instance.getVehicles.side_effect = PorscheException("Test")
-        instance.getAllTokens.return_value = async_return([])
-        yield
-
-
 @pytest.fixture
-def mock_client_update_error(mock_connection):
-    """Prevent setup."""
+def mock_climatisation_start(mock_connection):
+    """Mock the climatisation service action."""
     with patch(
-        "custom_components.porscheconnect.Client.getPosition",
-        side_effect=PorscheException,
-    ):
-        yield
-
-
-# This fixture, when used, will result in calls to async_get_data to return None. To have the call
-# return a value, we would add the `return_value=<VALUE_TO_RETURN>` parameter to the patch call.
-@pytest.fixture(name="bypass_connection_connect")
-def bypass_connection_connect_fixture():
-    print("Using bypass connection connect")
-    """Skip calls to get data from API."""
-    with patch("pyporscheconnectapi.connection.Connection._login"), patch(
-        "pyporscheconnectapi.connection.Connection.getAllTokens"
-    ):
-        yield
-
-
-# In this fixture, we are forcing calls to async_get_data to raise an Exception. This is useful
-# for exception handling.
-@pytest.fixture(name="error_connection_connect")
-def error_connection_connect_fixture():
-    """Simulate error when retrieving data from API."""
-    with patch(
-        "pyporscheconnectapi.connection.Connection._login",
-        side_effect=Exception,
-    ), patch("pyporscheconnectapi.connection.Connection.getAllTokens"):
-        yield
-
-
-# In this fixture, we are forcing calls to async_get_data to raise an Exception. This is useful
-# for exception handling.
-@pytest.fixture(name="error_connection_login")
-def error_connection_login_fixture():
-    """Simulate error when retrieving data from API."""
-    with patch(
-        "pyporscheconnectapi.connection.Connection._login",
-        side_effect=PorscheWrongCredentials,
-    ), patch("pyporscheconnectapi.connection.Connection.getAllTokens"):
-        yield
-
-
-# This fixture, when used, will result in calls to async_get_data to return None. To have the call
-# return a value, we would add the `return_value=<VALUE_TO_RETURN>` parameter to the patch call.
-@pytest.fixture(name="bypass_get_data")
-def bypass_get_data_fixture():
-    """Skip calls to get data from API."""
-    with patch(
-        "custom_components.porscheconnect.PorscheConnectApiClient.async_get_data"
-    ):
-        yield
-
-
-# In this fixture, we are forcing calls to async_get_data to raise an Exception. This is useful
-# for exception handling.
-@pytest.fixture(name="error_on_get_data")
-def error_get_data_fixture():
-    """Simulate error when retrieving data from API."""
-    with patch(
-        "custom_components.porscheconnect.PorscheConnectApiClient.async_get_data",
-        side_effect=Exception,
-    ):
-        yield
+        "pyporscheconnectapi.remote_services.RemoteServices.climatise_on",
+        AsyncMock(),
+    ) as climate_on:
+        yield climate_on

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_mock_porscheconnect_config_entry
 
-TEST_PARKING_BREAK_ENTITY_ID = "binary_sensor.taycan_turbo_s_parking_break"
+TEST_PARKING_BRAKE_ENTITY_ID = "binary_sensor.taycan_turbo_s_parking_brake"
 
 
 @pytest.mark.asyncio
@@ -14,5 +14,6 @@ async def test_pargking_break_sensor(hass: HomeAssistant, mock_connection) -> No
 
     await setup_mock_porscheconnect_config_entry(hass)
 
-    entity_state = hass.states.get(TEST_PARKING_BREAK_ENTITY_ID)
+    entity_state = hass.states.get(TEST_PARKING_BRAKE_ENTITY_ID)
+    assert entity_state
     assert entity_state.state == STATE_ON

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,105 +1,202 @@
 """Test Porsche Connect config flow."""
-from unittest.mock import patch
+
+import base64
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
-from custom_components.porscheconnect.const import (
-    DOMAIN,
-)
+from custom_components.porscheconnect import async_migrate_entry
+from custom_components.porscheconnect.const import DOMAIN
 from homeassistant import config_entries
-from homeassistant import data_entry_flow
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from .const import MOCK_CONFIG
 
+MOCK_TOKEN = {"access_token": "test-token"}
+MOCK_CAPTCHA = (
+    "data:image/svg+xml;base64,"
+    + base64.b64encode(
+        b'<svg width="150" height="50"></svg>',
+    ).decode()
+)
 
-# from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-
-# This fixture bypasses the actual setup of the integration
-# since we only want to test the config flow. We test the
-# actual functionality of the integration in other test modules.
 @pytest.fixture(autouse=True)
 def bypass_setup_fixture():
-    """Prevent setup."""
-    with patch(
-        "custom_components.porscheconnect.async_setup",
-        return_value=True,
-    ), patch(
-        "custom_components.porscheconnect.async_setup_entry",
-        return_value=True,
+    """Prevent setup of the integration during config flow tests."""
+    with (
+        patch(
+            "custom_components.porscheconnect.async_setup",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.porscheconnect.async_setup_entry",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.porscheconnect.async_unload_entry",
+            return_value=True,
+        ),
     ):
         yield
 
 
-# Here we simiulate a successful config flow from the backend.
-# Note that we use the `bypass_get_data` fixture here because
-# we want the config flow validation to succeed during the test.
-@pytest.mark.asyncio
-async def test_successful_config_flow(hass, bypass_connection_connect):
-    """Test a successful config flow."""
-    # Initialize a config flow
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+async def test_successful_config_flow(hass: HomeAssistant) -> None:
+    """Test a successful config flow without a captcha challenge."""
+    with patch(
+        "custom_components.porscheconnect.config_flow.validate_input",
+        AsyncMock(
+            return_value={
+                "title": MOCK_CONFIG[CONF_EMAIL],
+                CONF_ACCESS_TOKEN: MOCK_TOKEN,
+            },
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=MOCK_CONFIG,
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_CONFIG[CONF_EMAIL]
+    assert result["data"] == MOCK_CONFIG | {CONF_ACCESS_TOKEN: MOCK_TOKEN}
+
+
+async def test_captcha_auth_data_is_not_persisted(hass: HomeAssistant) -> None:
+    """Test captcha challenge data is used but not stored."""
+    validate = AsyncMock(
+        side_effect=[
+            {
+                **MOCK_CONFIG,
+                "captcha": MOCK_CAPTCHA,
+                "state": "test-state",
+                "code_verifier": "test-verifier",
+            },
+            {
+                "title": MOCK_CONFIG[CONF_EMAIL],
+                CONF_ACCESS_TOKEN: MOCK_TOKEN,
+            },
+        ],
+    )
+    with patch(
+        "custom_components.porscheconnect.config_flow.validate_input",
+        validate,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input=MOCK_CONFIG,
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "captcha"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"captcha_code": "test-code"},
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == MOCK_CONFIG | {CONF_ACCESS_TOKEN: MOCK_TOKEN}
+    assert validate.await_args_list == [
+        call(MOCK_CONFIG),
+        call(
+            {
+                **MOCK_CONFIG,
+                "captcha_code": "test-code",
+                "state": "test-state",
+                "code_verifier": "test-verifier",
+            },
+        ),
+    ]
+
+
+async def test_reconfigure_ignores_and_removes_stale_auth_data(
+    hass: HomeAssistant,
+) -> None:
+    """Test reconfigure does not resume a stale captcha challenge."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_CONFIG[CONF_EMAIL],
+        data={
+            **MOCK_CONFIG,
+            CONF_ACCESS_TOKEN: {"access_token": "old-token"},
+            "captcha_code": "stale-code",
+            "state": "stale-state",
+            "code_verifier": "stale-verifier",
+            "future_option": True,
+        },
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    new_password = "new-password"
+    validate = AsyncMock(
+        return_value={
+            "title": MOCK_CONFIG[CONF_EMAIL],
+            CONF_ACCESS_TOKEN: MOCK_TOKEN,
+        },
     )
 
-    # Check that the config flow shows the user form as the first step
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
+    with patch(
+        "custom_components.porscheconnect.config_flow.validate_input",
+        validate,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_RECONFIGURE,
+                "entry_id": entry.entry_id,
+            },
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "change_password"
 
-    # If a user were to enter `test_username` for username and `test_password`
-    # for password, it would result in this function call
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_CONFIG
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_PASSWORD: new_password},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    validate.assert_awaited_once_with(
+        {
+            CONF_EMAIL: MOCK_CONFIG[CONF_EMAIL],
+            CONF_PASSWORD: new_password,
+        },
     )
+    assert entry.data == {
+        CONF_EMAIL: MOCK_CONFIG[CONF_EMAIL],
+        CONF_PASSWORD: new_password,
+        CONF_ACCESS_TOKEN: MOCK_TOKEN,
+        "future_option": True,
+    }
 
-    # Check that the config flow is complete and a new entry is created with
-    # the input data
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "test_username"
-    assert result["data"] == MOCK_CONFIG
-    assert result["result"]
 
-
-# In this case, we want to simulate a failure during the config flow.
-# We use the `error_on_get_data` mock instead of `bypass_get_data`
-# (note the function parameters) to raise an Exception during
-# validation of the input config.
-@pytest.mark.asyncio
-async def test_failed_config_flow_connect(hass, error_connection_connect):
-    """Test a failed config flow due to credential validation failure."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
+async def test_migrate_entry_removes_transient_auth_data(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration removes authentication challenge data from stored entries."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            **MOCK_CONFIG,
+            CONF_ACCESS_TOKEN: MOCK_TOKEN,
+            "captcha_code": "stale-code",
+            "state": "stale-state",
+            "code_verifier": "stale-verifier",
+        },
+        version=1,
     )
+    entry.add_to_hass(hass)
 
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_CONFIG
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "connect"}
-
-
-# In this case, we want to simulate a failure during the config flow.
-# We use the `error_on_get_data` mock instead of `bypass_get_data`
-# (note the function parameters) to raise an Exception during
-# validation of the input config.
-@pytest.mark.asyncio
-async def test_failed_config_flow_login(hass, error_connection_login):
-    """Test a failed config flow due to credential validation failure."""
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_CONFIG
-    )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result["errors"] == {"base": "auth"}
+    assert await async_migrate_entry(hass, entry)
+    assert entry.version == 2
+    assert entry.data == MOCK_CONFIG | {CONF_ACCESS_TOKEN: MOCK_TOKEN}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,135 +1,76 @@
-"""Test Porsche Connect setup process."""
+"""Test Porsche Connect setup."""
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from custom_components.porscheconnect import async_reload_entry
-from custom_components.porscheconnect import async_setup_entry
-from custom_components.porscheconnect import async_unload_entry
 from custom_components.porscheconnect import PorscheConnectDataUpdateCoordinator
-from custom_components.porscheconnect.const import (
-    DOMAIN,
-)
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client
+from custom_components.porscheconnect.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from pyporscheconnectapi.connection import Connection
-from pyporscheconnectapi.account import PorscheConnectAccount
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pyporscheconnectapi.exceptions import PorscheExceptionError
 
-from .const import MOCK_CONFIG
-
-
-# We can pass fixtures as defined in conftest.py to tell pytest to use the fixture
-# for a given test. We can also leverage fixtures and mocks that are available in
-# Home Assistant using the pytest_homeassistant_custom_component plugin.
-# Assertions allow you to verify that the return value of whatever is on the left
-# side of the assertion matches with the right side.
-@pytest.mark.asyncio
-async def test_setup_unload_and_reload_entry(hass, mock_client):
-    """Test entry setup and unload."""
-    # Create a mock entry so we don't have to go through config flow
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-
-    # Set up the entry and assert that the values set during setup are where we expect
-    # them to be. Because we have patched the PorscheConnectDataUpdateCoordinator.async_get_data
-    # call, no code from custom_components/porscheconnect/api.py actually runs.
-    assert await async_setup_entry(hass, config_entry)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert (
-        type(hass.data[DOMAIN][config_entry.entry_id])
-        is PorscheConnectDataUpdateCoordinator
-    )
-
-    # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert (
-        type(hass.data[DOMAIN][config_entry.entry_id])
-        is PorscheConnectDataUpdateCoordinator
-    )
-
-    # Unload the entry and verify that the data has been removed
-    assert await async_unload_entry(hass, config_entry)
-    assert config_entry.entry_id not in hass.data[DOMAIN]
+from . import (
+    create_mock_porscheconnect_config_entry,
+    setup_mock_porscheconnect_config_entry,
+)
 
 
-@pytest.mark.asyncio
-async def test_setup_entry_exception(hass, mock_client_error):
-    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+async def test_setup_unload_and_reload_entry(
+    hass: HomeAssistant,
+    mock_connection,
+) -> None:
+    """Test entry setup, unload, and reload."""
+    entry = await setup_mock_porscheconnect_config_entry(hass)
 
-    # In this case we are testing the condition where async_setup_entry raises
-    # ConfigEntryNotReady using the `error_on_get_data` fixture which simulates
-    # an error.
-    with pytest.raises(ConfigEntryNotReady):
-        assert await async_setup_entry(hass, config_entry)
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.entry_id in hass.data[DOMAIN]
+    assert len(hass.data[DOMAIN][entry.entry_id].vehicles) == 1
 
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.entry_id not in hass.data[DOMAIN]
 
-# Here we simiulate a successful config flow from the backend.
-# Note that we use the `bypass_get_data` fixture here because
-# we want the config flow validation to succeed during the test.
-# async def test_configured_instances(hass, bypass_connection_connect):
-#     """Test a successful config flow."""
-#     # Initialize a config flow
-#     await hass.config_entries.flow.async_init(
-#         DOMAIN, context={"source": config_entries.SOURCE_USER}
-#     )
-@pytest.mark.asyncio
-async def test_setup_entry_initial_load(hass, mock_connection):
-    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-
-    # In this case we are testing the condition where async_setup_entry raises
-    # ConfigEntryNotReady using the `error_on_get_data` fixture which simulates
-    # an error.
-    assert await async_setup_entry(hass, config_entry)
-    assert len(hass.data[DOMAIN][config_entry.entry_id].vehicles) == 1
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.entry_id in hass.data[DOMAIN]
 
 
-@pytest.mark.asyncio
-@pytest.mark.only
-async def test_setup_entry_initial_load_privacy(hass, mock_connection_privacy):
-    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+async def test_setup_entry_api_error(
+    hass: HomeAssistant,
+    mock_connection_error,
+) -> None:
+    """Test an API error schedules config entry setup retry."""
+    entry = create_mock_porscheconnect_config_entry(hass)
 
-    # In this case we are testing the condition where async_setup_entry raises
-    # ConfigEntryNotReady using the `error_on_get_data` fixture which simulates
-    # an error.
-    assert await async_setup_entry(hass, config_entry)
-    assert len(hass.data[DOMAIN][config_entry.entry_id].vehicles) == 1
-
-    # This is a little hacky, we need to cover the case when privacy mode changes
-    # Couldn't find a clean way to use different versions of the fixture
-    update_coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    update_coordinator.config_entry = config_entry
-    update_coordinator.vehicles[0]["privacyMode"] = False
-    await update_coordinator._async_update_data()
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-@pytest.mark.asyncio
-async def test_setup_entry_initial_load_no_perms(hass, mock_connection, mock_noaccess):
-    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+async def test_setup_entry_initial_load(
+    hass: HomeAssistant,
+    mock_connection,
+) -> None:
+    """Test the initial vehicle load."""
+    entry = await setup_mock_porscheconnect_config_entry(hass)
 
-    assert await async_setup_entry(hass, config_entry)
-    assert len(hass.data[DOMAIN][config_entry.entry_id].vehicles) == 0
+    assert len(hass.data[DOMAIN][entry.entry_id].vehicles) == 1
+    vehicle = hass.data[DOMAIN][entry.entry_id].vehicles[0]
+    vehicle.get_stored_overview.assert_awaited_once_with()
+    vehicle.get_picture_locations.assert_awaited_once_with()
 
 
-@pytest.mark.asyncio
-async def test_update_error(hass, mock_connection, mock_client_update_error):
-    """Test ConfigEntryNotReady when API raises an exception during entry setup."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-
-    websession = aiohttp_client.async_get_clientsession(hass)
-    connection = Connection(
-        config_entry.data.get("email"),
-        config_entry.data.get("password"),
-        tokens=None,
-        websession=websession,
-    )
-    controller = PorscheConnectAccount(connection)
-
+async def test_coordinator_update_error(hass: HomeAssistant) -> None:
+    """Test API errors are exposed as coordinator update failures."""
+    entry = create_mock_porscheconnect_config_entry(hass)
+    controller = MagicMock()
+    controller.get_vehicles = AsyncMock(side_effect=PorscheExceptionError("Test"))
     coordinator = PorscheConnectDataUpdateCoordinator(
-        hass, config_entry=config_entry, controller=controller
+        hass,
+        config_entry=entry,
+        controller=controller,
     )
+
     with pytest.raises(UpdateFailed):
-        assert await coordinator._async_update_data()
+        await coordinator._async_update_data()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -36,10 +36,8 @@ async def test_door_lock(hass: HomeAssistant, mock_lock_lock, mock_lock_unlock) 
         },
         blocking=False,
     )
-    assert mock_lock_unlock.call_count == 0
     await hass.async_block_till_done()
-    mock_lock_unlock.assert_called_with("WPTAYCAN", "1234", True)
-    assert mock_lock_unlock.call_count == 1
+    mock_lock_unlock.assert_awaited_once_with("1234")
 
     await hass.services.async_call(
         LOCK_DOMAIN,
@@ -49,10 +47,8 @@ async def test_door_lock(hass: HomeAssistant, mock_lock_lock, mock_lock_unlock) 
         },
         blocking=False,
     )
-    assert mock_lock_lock.call_count == 0
     await hass.async_block_till_done()
-    mock_lock_lock.assert_called_with("WPTAYCAN", True)
-    assert mock_lock_lock.call_count == 1
+    mock_lock_lock.assert_awaited_once_with()
 
 
 # @pytest.mark.asyncio

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_mock_porscheconnect_config_entry
 
-TEST_CHARGING_LEVEL_NUMBER_ENTITY_ID = "number.taycan_turbo_s_charging_level_4"
+TEST_CHARGING_LEVEL_NUMBER_ENTITY_ID = "number.taycan_turbo_s_target_state_of_charge"
 
 
 @pytest.mark.asyncio
@@ -32,9 +32,5 @@ async def test_number(hass: HomeAssistant, mock_set_charging_level: MagicMock) -
         },
         blocking=False,
     )
-    assert mock_set_charging_level.call_count == 0
     await hass.async_block_till_done()
-    assert mock_set_charging_level.call_count == 1
-    mock_set_charging_level.assert_called_with(
-        "WPTAYCAN", None, 4, minimumChargeLevel=58.0
-    )
+    mock_set_charging_level.assert_awaited_once_with(target_soc=58)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 from . import setup_mock_porscheconnect_config_entry
 
 TEST_MILEAGE_SENSOR_ENTITY_ID = "sensor.taycan_turbo_s_mileage"
-TEST_CHARGER_SENSOR_ENTITY_ID = "sensor.taycan_turbo_s_charger"
+TEST_CHARGING_STATUS_SENSOR_ENTITY_ID = "sensor.taycan_turbo_s_charging_status"
 
 
 @pytest.mark.asyncio
@@ -25,6 +25,6 @@ async def test_charger_sensor(hass: HomeAssistant, mock_connection) -> None:
 
     await setup_mock_porscheconnect_config_entry(hass)
 
-    entity_state = hass.states.get(TEST_CHARGER_SENSOR_ENTITY_ID)
+    entity_state = hass.states.get(TEST_CHARGING_STATUS_SENSOR_ENTITY_ID)
     assert entity_state
-    assert entity_state.state == "NOT_CHARGING"
+    assert entity_state.state == "not_charging"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,65 +1,43 @@
-"""Test porscheconnect number."""
-from unittest.mock import MagicMock
+"""Test Porsche Connect services."""
 
-import pytest
-from custom_components.porscheconnect.const import DOMAIN as PORSCHE_DOMAIN
+from custom_components.porscheconnect.const import DOMAIN
+from custom_components.porscheconnect.services import SERVICE_CLIMATISATION_START
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from . import setup_mock_porscheconnect_config_entry
 
-SERVICE_HONK_AND_FLASH = "honk_and_flash"
-SERVICE_FLASH = "flash"
-ATTR_VEHICLE = "vehicle"
-
 
 def get_device_id(hass: HomeAssistant) -> str:
-    """Get device_id."""
+    """Return the test vehicle device ID."""
     device_registry = dr.async_get(hass)
-    identifiers = {(PORSCHE_DOMAIN, "WPTAYCAN")}
-    device = device_registry.async_get_device(identifiers)
+    device = device_registry.async_get_device({(DOMAIN, "WPTAYCAN")})
+    assert device
     return device.id
 
 
-@pytest.mark.asyncio
-async def test_honk_and_flash(
-    hass: HomeAssistant, mock_honk_and_flash: MagicMock
+async def test_climatisation_start(
+    hass: HomeAssistant,
+    mock_climatisation_start,
 ) -> None:
-    """Verify device information includes expected details."""
-
+    """Test starting climatisation through the integration service."""
     await setup_mock_porscheconnect_config_entry(hass)
-    data = {
-        ATTR_VEHICLE: get_device_id(hass),
-    }
 
     await hass.services.async_call(
-        PORSCHE_DOMAIN,
-        SERVICE_HONK_AND_FLASH,
-        data,
-        blocking=False,
+        DOMAIN,
+        SERVICE_CLIMATISATION_START,
+        {
+            "vehicle": get_device_id(hass),
+            "temperature": 20,
+            "front_left": True,
+        },
+        blocking=True,
     )
-    assert mock_honk_and_flash.call_count == 0
-    await hass.async_block_till_done()
-    assert mock_honk_and_flash.call_count == 1
-    mock_honk_and_flash.assert_called_with("WPTAYCAN", True)
 
-
-@pytest.mark.asyncio
-async def test_flash(hass: HomeAssistant, mock_flash: MagicMock) -> None:
-    """Verify device information includes expected details."""
-
-    await setup_mock_porscheconnect_config_entry(hass)
-    data = {
-        ATTR_VEHICLE: get_device_id(hass),
-    }
-
-    await hass.services.async_call(
-        PORSCHE_DOMAIN,
-        SERVICE_FLASH,
-        data,
-        blocking=False,
+    mock_climatisation_start.assert_awaited_once_with(
+        target_temperature=293.15,
+        front_left=True,
+        front_right=False,
+        rear_left=False,
+        rear_right=False,
     )
-    assert mock_flash.call_count == 0
-    await hass.async_block_till_done()
-    assert mock_flash.call_count == 1
-    mock_flash.assert_called_with("WPTAYCAN", True)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,8 +13,8 @@ from homeassistant.core import HomeAssistant
 
 from . import setup_mock_porscheconnect_config_entry
 
-TEST_CLIMATE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_climatisation"
-TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_direct_charge"
+TEST_CLIMATE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_remote_climatisation"
+TEST_CHARGE_SWITCH_ENTITY_ID = "switch.taycan_turbo_s_direct_charging"
 
 
 @pytest.mark.asyncio
@@ -36,9 +36,8 @@ async def test_climate(
         },
         blocking=False,
     )
-    assert mock_set_climate_on.call_count == 0
     await hass.async_block_till_done()
-    assert mock_set_climate_on.call_count == 1
+    mock_set_climate_on.assert_awaited_once_with()
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
@@ -47,9 +46,8 @@ async def test_climate(
         },
         blocking=False,
     )
-    assert mock_set_climate_off.call_count == 0
     await hass.async_block_till_done()
-    assert mock_set_climate_off.call_count == 1
+    mock_set_climate_off.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
@@ -71,9 +69,8 @@ async def test_directcharge(
         },
         blocking=False,
     )
-    assert mock_set_charge_on.call_count == 0
     await hass.async_block_till_done()
-    assert mock_set_charge_on.call_count == 1
+    mock_set_charge_on.assert_awaited_once_with()
     await hass.services.async_call(
         SWITCH_DOMAIN,
         SERVICE_TURN_OFF,
@@ -82,6 +79,5 @@ async def test_directcharge(
         },
         blocking=False,
     )
-    assert mock_set_charge_off.call_count == 0
     await hass.async_block_till_done()
-    assert mock_set_charge_off.call_count == 1
+    mock_set_charge_off.assert_awaited_once_with()


### PR DESCRIPTION
No longer store transient auth flow data in config entry, to avoid the risk of using stale data when reconfiguring.
Updates the test harness and cleaned up tests